### PR TITLE
fix jbuilder dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",
-    "@opam/jbuilder": "^1.0.0-beta14"
+    "@opam/jbuilder": "^1.0+beta14"
   },
   "peerDependencies": {
     "ocaml": "*"


### PR DESCRIPTION
`1.0.0-beta14` doesn't match any opam deps using opam's dep resolution algorithm. This change is required for esyi to work