### PR TITLE
Revert "fix jbuilder dep"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",
-    "@opam/jbuilder": "^1.0+beta14"
+    "@opam/jbuilder": "^1.0.0-beta14"
   },
   "peerDependencies": {
     "ocaml": "*"


### PR DESCRIPTION
Reverts esy-ocaml/fauxpam#2

I have to revert this because it breaks today's `esy install`.